### PR TITLE
UpdateVertex(**s**) as in Pseudocode Line 28"

### DIFF
--- a/python/python/d_star_lite.py
+++ b/python/python/d_star_lite.py
@@ -96,7 +96,7 @@ class DStarLite:
                                 if min_s > temp:
                                     min_s = temp
                             self.rhs[s] = min_s
-                    self.update_vertex(u)
+                    self.update_vertex(s)
 
     def rescan(self) -> Vertices:
 


### PR DESCRIPTION
If I am not mistaken, you are updating top key (u) instead of the list of neighbors. This unfortunately **does not fix** 

```python
min_s = float('inf')
arg_min = None

for s_ in succ:
    temp = self.c(self.s_start, s_) + self.g[s_]
    if temp < min_s:
        min_s = temp
        arg_min = s_
```

where, in some instances, argmin remains none. Any ideas to fix this?